### PR TITLE
Fix boost library link ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 SET(BOOST_COMPONENTS)
 LIST(APPEND BOOST_COMPONENTS thread
                              date_time
-                             system
                              filesystem
+                             system
                              chrono
                              unit_test_framework
                              locale)

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -878,7 +878,7 @@ namespace chainbase {
          }
 
          template< typename Lambda >
-         auto with_read_lock( Lambda&& callback, uint64_t wait_micro = 1000000 ) -> decltype( (*(Lambda*)nullptr)() )
+         auto with_read_lock( Lambda&& callback, uint64_t wait_micro = 1000000 ) const -> decltype( (*(Lambda*)nullptr)() )
          {
             read_lock lock( _rw_manager->current_lock(), bip::defer_lock_type() );
 #ifdef CHAINBASE_CHECK_LOCKING


### PR DESCRIPTION
boost filesystem uses boost system. Set the link order accordingly. Fixes boost 1.66 linkage on Linux with ld.

Review note: This also seems to include @brianjohnson5972 Aug4 2017 commit as it was never put in master. My plan is to merge these back to master and then update EOS to point at the resulting commit. Be aware there are commits in master that are not part of the tree currently pointed to by EOS.