### PR TITLE
more rigorous clean shutdown detection for mapped DB

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -55,6 +55,8 @@ namespace chainbase {
    template<typename T>
    using shared_vector = std::vector<T, allocator<T> >;
 
+   constexpr char _db_dirty_flag_string[] = "db_dirty_flag";
+
    struct strcmp_less
    {
       bool operator()( const shared_string& a, const shared_string& b )const


### PR DESCRIPTION
add a flag within the memory mapped DB that indicates if the DB was safely flushed to disk. Ensure that the rest of the DB is entirely out to disk before setting the flag indicating that the DB is clean.

Does not support win32; boost is very private with the underlying handles here and I couldn't quickly figure out a way to get the win32 file handle that is needed to do a synchronous flush

review note: it's probably safe if only a single dirty flag is used instead of one on each DB. As long as both are MS_SYNC before setting a single flag it seems like it'll be fine. Left two flags for now.