### PR TITLE
add_index ensures that the undo stack and revision of the added index are consistent with the other indices in the database

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -808,6 +808,13 @@ namespace chainbase {
                      ) );
                   }
 
+                  if( _read_only ) {
+                     BOOST_THROW_EXCEPTION( std::logic_error(
+                        "new index for " + type_name +
+                        " requires an undo stack that is consistent with other indices in the database; cannot fix in read-only mode"
+                     ) );
+                  }
+
                   idx_ptr->set_revision( expected_revision_range.first );
                   while( idx_ptr->revision() < expected_revision_range.second ) {
                      idx_ptr->start_undo_session(true).push();


### PR DESCRIPTION
`add_index` will modify the index undo stack as necessary (if possible) to `commit` up to the revision of the earliest undo state in the existing database and to add undo states as necessary to update its latest revision to that of the latest revision in the existing database. `add_index` will fail if the latest revision of the added index (which is already stored in the database) is higher than the latest revision in the existing database.
