### PR TITLE
Implement signals for adding plugin hook support in nodeos

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -557,6 +557,7 @@ namespace chainbase {
          }
 
          const auto &stack() const { return _stack; }
+
          mutable signal_op_type applied_emplace;
          mutable signal_op_type applied_modify;
          mutable signal_op_type applied_remove;


### PR DESCRIPTION
This adds the required signals for the proposed nodeos statetrack_plugin to hook into.
Another pull request has been opened at https://github.com/EOSIO/eos/pull/6321 to review that implementation.

Details about the approach and open questions can be found in the readme file of the plugin: https://github.com/mmcs85/eos/tree/master/plugins/statetrack_plugin

Details about how the operations should be handled by a receiver can be found in the statemirror repository: https://github.com/andresberrios/statemirror