### PR TITLE
change undo stack processing order to created-modified-removed

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -318,18 +318,18 @@ namespace chainbase {
 
             const auto& head = _stack.back();
 
+            for( auto id : head.new_ids )
+            {
+               _indices.erase( _indices.find( id ) );
+            }
+            _next_id = head.old_next_id;
+
             for( auto& item : head.old_values ) {
                auto ok = _indices.modify( _indices.find( item.second.id ), [&]( value_type& v ) {
                   v = std::move( item.second );
                });
                if( !ok ) BOOST_THROW_EXCEPTION( std::logic_error( "Could not modify object, most likely a uniqueness constraint was violated" ) );
             }
-
-            for( auto id : head.new_ids )
-            {
-               _indices.erase( _indices.find( id ) );
-            }
-            _next_id = head.old_next_id;
 
             for( auto& item : head.removed_values ) {
                bool ok = _indices.emplace( std::move( item.second ) ).second;


### PR DESCRIPTION
With current undo stacks processing order: modified, created, removed, there will be a dead loop for the following example code.
```
struct book : public chainbase::object<0, book> {
   template<typename Constructor, typename Allocator>
    book(  Constructor&& c, Allocator&& a ) {
       c(*this);
    }

    id_type id;
    id_type  a;
};

typedef multi_index_container<
  book,
  indexed_by<
     ordered_unique< member<book,book::id_type,&book::id> >,
     ordered_unique< member<book,book::id_type,&book::a> >,
     ordered_non_unique< BOOST_MULTI_INDEX_MEMBER(book,int,b) >
  >,
  chainbase::allocator<book>
> book_index;

const auto& new_book = db.create<book>( []( book& b ) {
    b.a = 10;
 } );

auto session = db.start_undo_session(true);

db.modify( new_book, [&]( book& b ) {
   b.a = 20;
});

const auto& another_book = db.create<book>( []( book& b ) {
    b.a = 10;
} );

db.undo();
```

So we need to change the undo stacks processing order to created, modified, removed. The issue in above code can be fixed.

Actually there are four cases to make the unique key conflict. Say we have two records (A, B) in one table which has unique key. The four cases are:
1) remove A, then create new record C which will use A's original value for C's the unique key
2) remove A, then modify B's unique key value to A's
3) modify A (change its unique key to other value), then create new record C which use A's original value as its unique key
4) modify A (change its unique key to other value), then modify B's unique key value to A's

With original undo stack processing order (modified, created, removed), case 3) will has issue which is showed in the example code above. 

With the changed undo stack processing order (created, modified, removed), case 1) 2) 3) all work fine. 

The case 4) is the most complicated one. You can even make the modified undo stack has two records that A and B have swapped their original value.  This fix can not handle this case. 
