### PR TITLE
chainbase database memory locking & hugepage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 
 file(GLOB HEADERS "include/chainbase/*.hpp")
-add_library( chainbase src/chainbase.cpp ${HEADERS} )
+add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS} )
 target_link_libraries( chainbase  ${Boost_LIBRARIES} ${PLATFORM_LIBRARIES} )
 target_include_directories( chainbase PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"  ${Boost_INCLUDE_DIR} )
 

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -9,7 +9,6 @@
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/sync/interprocess_sharable_mutex.hpp>
 #include <boost/interprocess/sync/sharable_lock.hpp>
-#include <boost/interprocess/sync/file_lock.hpp>
 
 #include <boost/multi_index_container.hpp>
 
@@ -27,6 +26,8 @@
 #include <stdexcept>
 #include <typeindex>
 #include <typeinfo>
+
+#include <chainbase/pinnable_mapped_file.hpp>
 
 #ifndef CHAINBASE_NUM_RW_LOCKS
    #define CHAINBASE_NUM_RW_LOCKS 10
@@ -48,14 +49,12 @@ namespace chainbase {
    using std::vector;
 
    template<typename T>
-   using allocator = bip::allocator<T, bip::managed_mapped_file::segment_manager>;
+   using allocator = bip::allocator<T, pinnable_mapped_file::segment_manager>;
 
    typedef bip::basic_string< char, std::char_traits< char >, allocator< char > > shared_string;
 
    template<typename T>
    using shared_vector = std::vector<T, allocator<T> >;
-
-   constexpr char _db_dirty_flag_string[] = "db_dirty_flag";
 
    struct strcmp_less
    {
@@ -689,7 +688,9 @@ namespace chainbase {
 
          using database_index_row_count_multiset = std::multiset<std::pair<unsigned, std::string>>;
 
-         database(const bfs::path& dir, open_flags write = read_only, uint64_t shared_file_size = 0, bool allow_dirty = false);
+         database(const bfs::path& dir, open_flags write = read_only, uint64_t shared_file_size = 0, bool allow_dirty = false,
+                  pinnable_mapped_file::map_mode = pinnable_mapped_file::map_mode::mapped,
+                  std::vector<std::string> hugepage_paths = std::vector<std::string>());
          ~database();
          database(database&&) = default;
          database& operator=(database&&) = default;
@@ -786,14 +787,18 @@ namespace chainbase {
                BOOST_THROW_EXCEPTION( std::logic_error( type_name + "::type_id is already in use" ) );
             }
 
-            index_type* idx_ptr = _segment->find< index_type >( type_name.c_str() ).first;
+            index_type* idx_ptr = nullptr;
+            if( _read_only )
+               idx_ptr = _db_file.get_segment_manager()->find_no_lock< index_type >( type_name.c_str() ).first;
+            else
+               idx_ptr = _db_file.get_segment_manager()->find< index_type >( type_name.c_str() ).first;
             bool first_time_adding = false;
             if( !idx_ptr ) {
                if( _read_only ) {
                   BOOST_THROW_EXCEPTION( std::runtime_error( "unable to find index for " + type_name + " in read only database" ) );
                }
                first_time_adding = true;
-               idx_ptr = _segment->construct< index_type >( type_name.c_str() )( index_alloc( _segment->get_segment_manager() ) );
+               idx_ptr = _db_file.get_segment_manager()->construct< index_type >( type_name.c_str() )( index_alloc( _db_file.get_segment_manager() ) );
              }
 
             idx_ptr->validate();
@@ -838,17 +843,17 @@ namespace chainbase {
             _index_list.push_back( new_index );
          }
 
-         auto get_segment_manager() -> decltype( ((bip::managed_mapped_file*)nullptr)->get_segment_manager()) {
-            return _segment->get_segment_manager();
+         auto get_segment_manager() -> decltype( ((pinnable_mapped_file*)nullptr)->get_segment_manager()) {
+            return _db_file.get_segment_manager();
          }
 
-         auto get_segment_manager()const -> std::add_const_t< decltype( ((bip::managed_mapped_file*)nullptr)->get_segment_manager() ) > {
-            return _segment->get_segment_manager();
+         auto get_segment_manager()const -> std::add_const_t< decltype( ((pinnable_mapped_file*)nullptr)->get_segment_manager() ) > {
+            return _db_file.get_segment_manager();
          }
 
          size_t get_free_memory()const
          {
-            return _segment->get_segment_manager()->get_free_memory();
+            return _db_file.get_segment_manager()->get_free_memory();
          }
 
          template<typename MultiIndexType>
@@ -956,58 +961,6 @@ namespace chainbase {
              return get_mutable_index<index_type>().emplace( std::forward<Constructor>(con) );
          }
 
-         template< typename Lambda >
-         auto with_read_lock( Lambda&& callback, uint64_t wait_micro = 1000000 ) const -> decltype( (*(Lambda*)nullptr)() )
-         {
-            read_lock lock( _rw_manager->current_lock(), bip::defer_lock_type() );
-#ifdef CHAINBASE_CHECK_LOCKING
-            BOOST_ATTRIBUTE_UNUSED
-            int_incrementer ii( _read_lock_count );
-#endif
-
-            if( !wait_micro )
-            {
-               lock.lock();
-            }
-            else
-            {
-
-               if( !lock.timed_lock( boost::posix_time::microsec_clock::local_time() + boost::posix_time::microseconds( wait_micro ) ) )
-                  BOOST_THROW_EXCEPTION( std::runtime_error( "unable to acquire lock" ) );
-            }
-
-            return callback();
-         }
-
-         template< typename Lambda >
-         auto with_write_lock( Lambda&& callback, uint64_t wait_micro = 1000000 ) -> decltype( (*(Lambda*)nullptr)() )
-         {
-            if( _read_only )
-               BOOST_THROW_EXCEPTION( std::logic_error( "cannot acquire write lock on read-only process" ) );
-
-            write_lock lock( _rw_manager->current_lock(), boost::defer_lock_t() );
-#ifdef CHAINBASE_CHECK_LOCKING
-            BOOST_ATTRIBUTE_UNUSED
-            int_incrementer ii( _write_lock_count );
-#endif
-
-            if( !wait_micro )
-            {
-               lock.lock();
-            }
-            else
-            {
-               while( !lock.timed_lock( boost::posix_time::microsec_clock::local_time() + boost::posix_time::microseconds( wait_micro ) ) )
-               {
-                  _rw_manager->next_lock();
-                  std::cerr << "Lock timeout, moving to lock " << _rw_manager->current_lock_num() << std::endl;
-                  lock = write_lock( _rw_manager->current_lock(), boost::defer_lock_t() );
-               }
-            }
-
-            return callback();
-         }
-
          database_index_row_count_multiset row_count_per_index()const {
             database_index_row_count_multiset ret;
             for(const auto& ai_ptr : _index_map) {
@@ -1019,11 +972,8 @@ namespace chainbase {
          }
 
       private:
-         unique_ptr<bip::managed_mapped_file>                        _segment;
-         unique_ptr<bip::managed_mapped_file>                        _meta;
-         read_write_mutex_manager*                                   _rw_manager = nullptr;
+         pinnable_mapped_file                                        _db_file;
          bool                                                        _read_only = false;
-         bip::file_lock                                              _flock;
 
          /**
           * This is a sparse list of known indices kept to accelerate creation of undo sessions
@@ -1035,15 +985,11 @@ namespace chainbase {
           */
          vector<unique_ptr<abstract_index>>                          _index_map;
 
-         bfs::path                                                   _data_dir;
-
 #ifdef CHAINBASE_CHECK_LOCKING
          int32_t                                                     _read_lock_count = 0;
          int32_t                                                     _write_lock_count = 0;
          bool                                                        _enable_require_locking = false;
 #endif
-
-         void                                                        _msync_database();
    };
 
    template<typename Object, typename... Args>

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <boost/interprocess/managed_mapped_file.hpp>
+#include <boost/interprocess/sync/file_lock.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/asio/io_service.hpp>
+
+namespace chainbase {
+
+namespace bip = boost::interprocess;
+namespace bfs = boost::filesystem;
+
+constexpr char _db_dirty_flag_string[] = "db_dirty_flag";
+
+class pinnable_mapped_file {
+   public:
+      typedef typename bip::managed_mapped_file::segment_manager segment_manager;
+
+      enum map_mode {
+         mapped,
+         heap,
+         locked
+      };
+
+      pinnable_mapped_file(const bfs::path& dir, bool writable, uint64_t shared_file_size, bool allow_dirty, map_mode mode, std::vector<std::string> hugepage_paths);
+      ~pinnable_mapped_file();
+
+      segment_manager* get_segment_manager() const { return _segment_manager;}
+
+   private:
+      void                                          msync_boost_mapped_file();
+      void                                          load_database_file(boost::asio::io_service& sig_ios);
+      void                                          save_database_file();
+      void                                          finialize_database_file(bool*);
+      bool                                          all_zeros(char* data, size_t sz);
+      bip::mapped_region                            get_huge_region(const std::vector<std::string>& huge_paths);
+
+      std::unique_ptr<bip::managed_mapped_file>     _mapped_file;
+      bip::file_lock                                _mapped_file_lock;
+      bfs::path                                     _data_file_path;
+      std::string                                   _database_name;
+      bool                                          _writable;
+
+      bip::mapped_region                            _mapped_region;
+
+#ifdef _WIN32
+      bip::permissions                              _db_permissions
+#else
+      bip::permissions                              _db_permissions{S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH};
+#endif
+
+      segment_manager*                              _segment_manager = nullptr;
+
+      constexpr static unsigned                     _db_size_multiple_requirement = 1024*1024; //1MB
+};
+
+std::istream& operator>>(std::istream& in, pinnable_mapped_file::map_mode& runtime);
+std::ostream& operator<<(std::ostream& osm, pinnable_mapped_file::map_mode m);
+
+}

--- a/src/chainbase.cpp
+++ b/src/chainbase.cpp
@@ -26,6 +26,9 @@ namespace chainbase {
          return std::make_tuple( a.compiler_version, a.debug, a.apple, a.windows, a.boost_version )
             ==  std::make_tuple( b.compiler_version, b.debug, b.apple, b.windows, b.boost_version );
       }
+      friend bool operator != ( const environment_check& a, const environment_check& b ) {
+         return !(a == b);
+      }
 
       boost::array<char,256>  compiler_version;
       bool                    debug = false;
@@ -34,168 +37,60 @@ namespace chainbase {
       uint32_t                boost_version;
    };
 
-   database::database(const bfs::path& dir, open_flags flags, uint64_t shared_file_size, bool allow_dirty ) {
-      bool write = flags & database::read_write;
-
-      if (!bfs::exists(dir)) {
-         if(!write) BOOST_THROW_EXCEPTION( std::runtime_error( "database file not found at " + dir.native() ) );
-      }
-
-      bfs::create_directories(dir);
-
-      _data_dir = dir;
-      auto abs_path = bfs::absolute( dir / "shared_memory.bin" );
-
-      if( bfs::exists( abs_path ) )
-      {
-         if( write )
-         {
-            auto existing_file_size = bfs::file_size( abs_path );
-            if( shared_file_size > existing_file_size )
-            {
-               if( !bip::managed_mapped_file::grow( abs_path.generic_string().c_str(), shared_file_size - existing_file_size ) )
-                  BOOST_THROW_EXCEPTION( std::runtime_error( "could not grow database file to requested size." ) );
-            }
-
-            _segment.reset( new bip::managed_mapped_file( bip::open_only,
-                                                          abs_path.generic_string().c_str()
-                                                          ) );
-         } else {
-            _segment.reset( new bip::managed_mapped_file( bip::open_read_only,
-                                                          abs_path.generic_string().c_str()
-                                                          ) );
-            _read_only = true;
-         }
-
-         auto env = _segment->find< environment_check >( "environment" );
-         auto host_env = environment_check();
-         if( !env.first || !( *env.first == host_env ) ) {
-            std::cerr << "database created by a different compiler, build, boost version, or operating system\n"
-                      << "Environment differences (host vs database):"
-                      << "\n Compiler Version: \n"
-                      <<   "                   " << std::hex;
-            for( uint32_t i = 0; i < 256; ++i ) {
-               char b = *(host_env.compiler_version.data() + i);
-               std::cerr << (uint16_t)b;
-            }
-            std::cerr << " \"";
-            for( uint32_t i = 0; i < 256; ++i ) {
-               char b = *(host_env.compiler_version.data() + i);
-               if( !b ) break;
-               std::cerr << b;
-            }
-            std::cerr << " \"";
-            std::cerr << "\n                   vs\n"
-                      <<   "                   ";
-            for( uint32_t i = 0; i < 256; ++i ) {
-               char b = *(env.first->compiler_version.data() + i);
-               std::cerr << (uint16_t)b;
-            }
-            std::cerr << " \"";
-            for( uint32_t i = 0; i < 256; ++i ) {
-               char b = *(env.first->compiler_version.data() + i);
-               if( !b ) break;
-               std::cerr << b;
-            }
-            std::cerr << " \"" << std::dec;
-            std::cerr << "\n Debug: " << host_env.debug << " vs " << env.first->debug
-                      << "\n Apple: " << host_env.apple << " vs " << env.first->apple
-                      << "\n Windows: " << host_env.windows << " vs " << env.first->windows
-                      << "\n Boost Version: " << host_env.boost_version << " vs " << env.first->boost_version
-                      << std::endl;
-
-            BOOST_THROW_EXCEPTION( std::runtime_error( "database created by a different compiler, build, boost version, or operating system" ) );
-         }
-      } else {
-         _segment.reset( new bip::managed_mapped_file( bip::create_only,
-                                                       abs_path.generic_string().c_str(), shared_file_size,
-                                                       0, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH
-                                                       ) );
-         _segment->find_or_construct< environment_check >( "environment" )();
-      }
-
-      abs_path = bfs::absolute( dir / "shared_memory.meta" );
-
-      if( bfs::exists( abs_path ) )
-      {
-         _meta.reset( new bip::managed_mapped_file( bip::open_only, abs_path.generic_string().c_str()
-                                                    ) );
-
-         _rw_manager = _meta->find< read_write_mutex_manager >( "rw_manager" ).first;
-         if( !_rw_manager )
-            BOOST_THROW_EXCEPTION( std::runtime_error( "could not find read write lock manager" ) );
-      }
+   database::database(const bfs::path& dir, open_flags flags, uint64_t shared_file_size, bool allow_dirty,
+                      pinnable_mapped_file::map_mode db_map_mode, std::vector<std::string> hugepage_paths ) :
+      _db_file(dir, flags & database::read_write, shared_file_size, allow_dirty, db_map_mode, hugepage_paths),
+      _read_only(flags == database::read_only)
+   {
+      environment_check* env = nullptr;
+      if(_read_only)
+         env = _db_file.get_segment_manager()->find_no_lock< environment_check >( "environment" ).first;
       else
-      {
-         _meta.reset( new bip::managed_mapped_file( bip::create_only,
-                                                    abs_path.generic_string().c_str(), sizeof( read_write_mutex_manager ) * 2,
-                                                    0, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH
-                                                    ) );
+         env = _db_file.get_segment_manager()->find_or_construct< environment_check >( "environment" )();
+      environment_check host_env = environment_check();
+      if( *env != host_env ) {
+         std::cerr << "database created by a different compiler, build, boost version, or operating system\n"
+                     << "Environment differences (host vs database):"
+                     << "\n Compiler Version: \n"
+                     <<   "                   " << std::hex;
+         for( uint32_t i = 0; i < 256; ++i ) {
+            char b = *(host_env.compiler_version.data() + i);
+            std::cerr << (uint16_t)b;
+         }
+         std::cerr << " \"";
+         for( uint32_t i = 0; i < 256; ++i ) {
+            char b = *(host_env.compiler_version.data() + i);
+            if( !b ) break;
+            std::cerr << b;
+         }
+         std::cerr << " \"";
+         std::cerr << "\n                   vs\n"
+                     <<   "                   ";
+         for( uint32_t i = 0; i < 256; ++i ) {
+            char b = *(env->compiler_version.data() + i);
+            std::cerr << (uint16_t)b;
+         }
+         std::cerr << " \"";
+         for( uint32_t i = 0; i < 256; ++i ) {
+            char b = *(env->compiler_version.data() + i);
+            if( !b ) break;
+            std::cerr << b;
+         }
+         std::cerr << " \"" << std::dec;
+         std::cerr << "\n Debug: " << host_env.debug << " vs " << env->debug
+                     << "\n Apple: " << host_env.apple << " vs " << env->apple
+                     << "\n Windows: " << host_env.windows << " vs " << env->windows
+                     << "\n Boost Version: " << host_env.boost_version << " vs " << env->boost_version
+                     << std::endl;
 
-         _rw_manager = _meta->find_or_construct< read_write_mutex_manager >( "rw_manager" )();
-      }
-
-      bool* db_is_dirty   = nullptr;
-      bool* meta_is_dirty = nullptr;
-
-      if( write )
-      {
-         db_is_dirty = _segment->get_segment_manager()->find_or_construct<bool>(_db_dirty_flag_string)(false);
-         meta_is_dirty = _meta->get_segment_manager()->find_or_construct<bool>(_db_dirty_flag_string)(false);
-      } else {
-         db_is_dirty = _segment->get_segment_manager()->find_no_lock<bool>(_db_dirty_flag_string).first;
-         meta_is_dirty = _meta->get_segment_manager()->find_no_lock<bool>(_db_dirty_flag_string).first;
-      }
-
-      if( db_is_dirty == nullptr || meta_is_dirty == nullptr )
-         BOOST_THROW_EXCEPTION( std::runtime_error( "could not find dirty flag in shared memory" ) );
-
-      if( !allow_dirty && *db_is_dirty )
-         throw std::runtime_error( "database dirty flag set" );
-      if( !allow_dirty && *meta_is_dirty )
-         throw std::runtime_error( "database metadata dirty flag set" );
-
-      if( write ) {
-         _flock = bip::file_lock( abs_path.generic_string().c_str() );
-         if( !_flock.try_lock() )
-            BOOST_THROW_EXCEPTION( std::runtime_error( "could not gain write access to the shared memory file" ) );
-
-         *db_is_dirty = *meta_is_dirty = true;
-         _msync_database();
+         BOOST_THROW_EXCEPTION( std::runtime_error( "database created by a different compiler, build, boost version, or operating system" ) );
       }
    }
 
    database::~database()
    {
-      if(!_read_only) {
-         _msync_database();
-         *_segment->get_segment_manager()->find<bool>(_db_dirty_flag_string).first = false;
-         *_meta->get_segment_manager()->find<bool>(_db_dirty_flag_string).first = false;
-         _msync_database();
-      }
-      _segment.reset();
-      _meta.reset();
       _index_list.clear();
       _index_map.clear();
-      _data_dir = bfs::path();
-   }
-
-   void database::flush() {
-      if( _segment )
-         _segment->flush();
-      if( _meta )
-         _meta->flush();
-   }
-
-   void database::_msync_database() {
-#ifdef _WIN32
-#warning Safe database dirty handling not implemented on WIN32
-#else
-         if(msync(_segment->get_address(), _segment->get_size(), MS_SYNC))
-            perror("Failed to msync DB file");
-         if(msync(_meta->get_address(), _meta->get_size(), MS_SYNC))
-            perror("Failed to msync DB metadata file");
-#endif
    }
 
    void database::set_require_locking( bool enable_require_locking )

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -1,0 +1,274 @@
+#include <chainbase/pinnable_mapped_file.hpp>
+#include <boost/interprocess/managed_external_buffer.hpp>
+#include <boost/interprocess/anonymous_shared_memory.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <iostream>
+
+#ifdef __linux__
+#include <sys/vfs.h>
+#include <linux/magic.h>
+#endif
+
+namespace chainbase {
+
+pinnable_mapped_file::pinnable_mapped_file(const bfs::path& dir, bool writable, uint64_t shared_file_size, bool allow_dirty,
+                                          map_mode mode, std::vector<std::string> hugepage_paths) :
+   _data_file_path(bfs::absolute(dir/"shared_memory.bin")),
+   _database_name(dir.filename().string()),
+   _writable(writable)
+{
+   if(shared_file_size % _db_size_multiple_requirement)
+      BOOST_THROW_EXCEPTION(std::runtime_error("Database must be mulitple of " + std::to_string(_db_size_multiple_requirement) + " bytes"));
+#ifndef __linux__
+   if(hugepage_paths.size())
+      BOOST_THROW_EXCEPTION(std::runtime_error("Hugepage support is a linux only feature"));
+#endif
+   if(hugepage_paths.size() && mode != locked)
+      BOOST_THROW_EXCEPTION(std::runtime_error("Locked mode is required for hugepage usage"));
+#ifdef _WIN32
+   if(mode == locked)
+      BOOST_THROW_EXCEPTION(std::runtime_error("Locked mode not supported on win32"));
+#endif
+
+   if(!_writable && !bfs::exists(_data_file_path))
+      BOOST_THROW_EXCEPTION(std::runtime_error("database file not found at " + _data_file_path.native()));
+   bfs::create_directories(dir);
+
+   if(bfs::exists(_data_file_path)) {
+      if(_writable) {
+         auto existing_file_size = bfs::file_size(_data_file_path);
+         if(shared_file_size > existing_file_size) {
+            if(!bip::managed_mapped_file::grow(_data_file_path.generic_string().c_str(), shared_file_size - existing_file_size))
+               BOOST_THROW_EXCEPTION(std::runtime_error( "could not grow database file to requested size."));
+         }
+
+         _mapped_file = std::make_unique<bip::managed_mapped_file>(bip::open_only,
+                                                                   _data_file_path.generic_string().c_str());
+      } else {
+         _mapped_file = std::make_unique<bip::managed_mapped_file>(bip::open_read_only,
+                                                                   _data_file_path.generic_string().c_str());
+      }
+   }
+   else {
+         _mapped_file = std::make_unique<bip::managed_mapped_file>(bip::create_only,
+                                                                   _data_file_path.generic_string().c_str(),
+                                                                   shared_file_size, nullptr, _db_permissions);
+   }
+
+   if(_writable) {
+      boost::system::error_code ec;
+      bfs::remove(bfs::absolute(dir/"shared_memory.meta"), ec);
+   }
+
+   bool* db_is_dirty  = nullptr;
+
+   if(_writable)
+      db_is_dirty = _mapped_file->find_or_construct<bool>(_db_dirty_flag_string)(false);
+   else
+      db_is_dirty = _mapped_file->find_no_lock<bool>(_db_dirty_flag_string).first;
+
+   if(db_is_dirty == nullptr)
+      BOOST_THROW_EXCEPTION(std::runtime_error( "could not find dirty flag in shared memory"));
+
+   if(!allow_dirty && *db_is_dirty)
+      throw std::runtime_error("database dirty flag set");
+
+   if(_writable) {
+      _mapped_file_lock = bip::file_lock(_data_file_path.generic_string().c_str());
+      if(!_mapped_file_lock.try_lock())
+         BOOST_THROW_EXCEPTION(std::runtime_error("could not gain write access to the shared memory file"));
+
+      *db_is_dirty = true;
+      msync_boost_mapped_file();
+   }
+
+   if(mode == mapped) {
+      _segment_manager = _mapped_file->get_segment_manager();
+   }
+   else {
+      boost::asio::io_service sig_ios;
+      boost::asio::signal_set sig_set(sig_ios, SIGINT, SIGTERM, SIGPIPE);
+      sig_set.async_wait([](const boost::system::error_code&, int) {
+         BOOST_THROW_EXCEPTION(std::runtime_error("Database load aborted"));
+      });
+
+      try {
+         if(mode == heap)
+            _mapped_region = bip::mapped_region(bip::anonymous_shared_memory(shared_file_size));
+         else
+            _mapped_region = get_huge_region(hugepage_paths);
+
+         load_database_file(sig_ios);
+
+         if(mode == locked) {
+#ifndef _WIN32
+            if(mlock(_mapped_region.get_address(), _mapped_region.get_size()))
+               BOOST_THROW_EXCEPTION(std::runtime_error("Failed to mlock database \"" + _database_name + "\""));
+            std::cerr << "CHAINBASE: Database \"" << _database_name << "\" has been successfully locked in memory" << std::endl;
+#endif
+         }
+      }
+      catch(...) {
+         *db_is_dirty = false;
+         msync_boost_mapped_file();
+         throw;
+      }
+
+      /* a managed_mapped_file contains a header used for "atomic" creation that steals some bytes
+         from the useable space, compute this using a non-private api to figure out where the segment_manager
+         exists in the mapped file */
+      size_t segment_offset = _mapped_file->get_size() - _mapped_file->get_segment_manager()->get_size();
+      _mapped_file.reset();
+      _segment_manager = reinterpret_cast<segment_manager*>((char*)_mapped_region.get_address()+segment_offset);
+   }
+}
+
+bip::mapped_region pinnable_mapped_file::get_huge_region(const std::vector<std::string>& huge_paths) {
+   std::map<unsigned, std::string> page_size_to_paths;
+   const auto mapped_file_size = _mapped_file->get_size();
+
+#ifdef __linux__
+   for(const std::string& p : huge_paths) {
+      struct statfs fs;
+      if(statfs(p.c_str(), &fs))
+         BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Could not statfs() path ") + p));
+      if(fs.f_type != HUGETLBFS_MAGIC)
+         BOOST_THROW_EXCEPTION(std::runtime_error(p + std::string(" does not look like a hugepagefs mount")));
+      page_size_to_paths[fs.f_bsize] = p;
+   }
+   for(auto it = page_size_to_paths.rbegin(); it != page_size_to_paths.rend(); ++it) {
+      if(mapped_file_size % it->first == 0) {
+         bfs::path hugepath = bfs::unique_path(bfs::path(it->second + "/%%%%%%%%%%%%%%%%%%%%%%%%%%"));
+         int fd = creat(hugepath.string().c_str(), _db_permissions.get_permissions());
+         if(fd < 0)
+            BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Could not open hugepage file in ") + it->second + ": " + std::string(strerror(errno))));
+         if(ftruncate(fd, mapped_file_size))
+            BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Failed to grow hugepage file to specified size")));
+         close(fd);
+         bip::file_mapping filemap(hugepath.generic_string().c_str(), _writable ? bip::read_write : bip::read_only);
+         bfs::remove(hugepath);
+         std::cerr << "CHAINBASE: Database \"" << _database_name << "\" using " << it->first << " byte pages" << std::endl;
+         return bip::mapped_region(filemap, _writable ? bip::read_write : bip::read_only);
+      }
+   }
+#endif
+
+   std::cerr << "CHAINBASE: Database \"" << _database_name << "\" not using huge pages" << std::endl;
+   return bip::mapped_region(bip::anonymous_shared_memory(mapped_file_size));
+}
+
+void pinnable_mapped_file::load_database_file(boost::asio::io_service& sig_ios) {
+   std::cerr << "CHAINBASE: Preloading \"" << _database_name << "\" database file, this could take a moment..." << std::endl;
+   char* const src = (char*)_mapped_file->get_address();
+   char* const dst = (char*)_mapped_region.get_address();
+   size_t offset = 0;
+   time_t t = time(nullptr);
+   while(offset != _mapped_file->get_size()) {
+      memcpy(dst+offset, src+offset, _db_size_multiple_requirement);
+      offset += _db_size_multiple_requirement;
+
+      if(time(nullptr) != t) {
+         t = time(nullptr);
+         std::cerr << "              " << offset/(_mapped_region.get_size()/100) << "% complete..." << std::endl;
+      }
+      sig_ios.poll();
+   }
+   std::cerr << "           Complete" << std::endl;
+}
+
+bool pinnable_mapped_file::all_zeros(char* data, size_t sz) {
+   uint64_t* p = (uint64_t*)data;
+   uint64_t* end = p+sz/sizeof(uint64_t);
+   while(p != end) {
+      if(*p++ != 0)
+         return false;
+   }
+   return true;
+}
+
+void pinnable_mapped_file::save_database_file() {
+   bip::file_mapping filemap(_data_file_path.generic_string().c_str(), bip::read_write);
+   bip::mapped_region region(filemap, bip::read_write);
+
+   std::cerr << "CHAINBASE: Writing \"" << _database_name << "\" database file, this could take a moment..." << std::endl;
+   char* src = (char*)_mapped_region.get_address();
+   char* dst = (char*)region.get_address();
+   size_t offset = 0;
+   time_t t = time(nullptr);
+   while(offset != region.get_size()) {
+      if(!all_zeros(src+offset, _db_size_multiple_requirement))
+         memcpy(dst+offset, src+offset, _db_size_multiple_requirement);
+      offset += _db_size_multiple_requirement;
+
+      if(time(nullptr) != t) {
+         t = time(nullptr);
+         std::cerr << "              " << offset/(region.get_size()/100) << "% complete..." << std::endl;
+      }
+   }
+   std::cerr << "           Syncing buffers..." << std::endl;
+   if(region.flush(0, region.get_size(), false) == false)
+      std::cerr << "CHAINBASE: ERROR: syncing buffers failed" << std::endl;
+   std::cerr << "           Complete" << std::endl;
+}
+
+void pinnable_mapped_file::finialize_database_file(bool* dirty) {
+   bip::file_mapping filemap(_data_file_path.generic_string().c_str(), bip::read_write);
+   bip::mapped_region region(filemap, bip::read_write);
+
+   uintptr_t offset = (char*)dirty-(char*)_mapped_region.get_address();
+
+   memcpy((char*)(region.get_address())+offset, (char*)(_mapped_region.get_address())+offset, sizeof(bool));
+   if(region.flush(0, region.get_size(), false) == false)
+      std::cerr << "CHAINBASE: ERROR: syncing dirty bit failed" << std::endl;
+}
+
+pinnable_mapped_file::~pinnable_mapped_file() {
+   const bool is_heap_or_locked = _mapped_region.get_address();
+   if(_writable) {
+      if(is_heap_or_locked)
+         save_database_file();
+      bool* dirty = _segment_manager->find<bool>(_db_dirty_flag_string).first;
+      *dirty = false;
+      if(is_heap_or_locked)
+         finialize_database_file(dirty);
+      else
+         msync_boost_mapped_file();
+#ifdef _WIN32
+      std::cerr << "Warning: chainbase cannot ensure safe database sync on win32" << std::endl;
+#endif
+   }
+}
+
+void pinnable_mapped_file::msync_boost_mapped_file() {
+#ifndef _WIN32
+   if(msync(_mapped_file->get_address(), _mapped_file->get_size(), MS_SYNC))
+      perror("Failed to msync DB file");
+#endif
+}
+
+std::istream& operator>>(std::istream& in, pinnable_mapped_file::map_mode& runtime) {
+   std::string s;
+   in >> s;
+   if (s == "mapped")
+      runtime = pinnable_mapped_file::map_mode::mapped;
+   else if (s == "heap")
+      runtime = pinnable_mapped_file::map_mode::heap;
+   else if (s == "locked")
+      runtime = pinnable_mapped_file::map_mode::locked;
+   else
+      in.setstate(std::ios_base::failbit);
+   return in;
+}
+
+std::ostream& operator<<(std::ostream& osm, pinnable_mapped_file::map_mode m) {
+   if(m == pinnable_mapped_file::map_mode::mapped)
+      osm << "mapped";
+   else if (m == pinnable_mapped_file::map_mode::heap)
+      osm << "heap";
+   else if (pinnable_mapped_file::map_mode::locked)
+      osm << "locked";
+
+   return osm;
+}
+
+}


### PR DESCRIPTION
Modify chainbase's database to have 3 modes of operation: mapped, heap, and locked. While some aspects of these modes were obtainable without modifying chainbase's code (for example, it is possible to simulate “heap” mode by placing nodeos’ data directory in a tmpfs), exposing them in a user friendly manner may encourage uptake and reduce errors. The reasoning behind the effort is that I’ve measured greater than 10% improvement in database performance when using 1GB pages. This measurement comes from replaying parts of a popular EOSIO based blockchain with `--wasm wavm --disable-replay-opts`: replay is over 10% faster using locked 1GB pages vs heap mode.

Users can switch between the three modes of operation on startup without affecting compatibility of the database file. The modes of operation are:
* **mapped**: The classic behavior and still the default. Downsides are that the pages are faulted on demand (transactions near start of nodeos may be slower than otherwise) and that by default Linux will periodically flush dirty pages to disk which can cause high IO and potential CPU usage.
* **heap**: Prefaults the entire database in to anonymous memory (heap is a misnomer but maybe more friendly term?). Anonymous memory prevents Linux from periodically writing back data. This resolves some of the performance implications of mapped mode but has higher overhead on start and exit of nodeos as the entire DB file needs to be loaded and stored.
* **locked**: Heap mode with two differences: 1) requires `mlock()` to succeed on the anonymous mapping and 2) enables support for huge pages on Linux. When hugepagefs paths are passed in the database code will attempt to place the database file there instead of in anonymous memory.

At the time of writing, hugepages on Linux are not swappable. This means that hugepage usage is implicitly locked anyways. Regardless, the database code still requires `mlock()` on the hugepages to succeed and this still means ulimit has to be bumped appropriately. As such, there is a potential argument to be made that hugepages should be allowed in either heap or locked mode instead of the current requirement of locked only. Certainly something to mull on.

Examples of configurations will be provided in PR against main EOSIO repo.

A significant change to the database API was mode to simplify matters: removal of the with_read_lock & with_write_lock and the corresponding .meta file. These functions are not currently used to any effect. If a user launches a nodeos built before this change it was recreate the .meta file with no side effects.