### PR TITLE
Remove boost thread include and unused typedef - 1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,11 @@ cmake_minimum_required( VERSION 2.8.12 )
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
 SET(BOOST_COMPONENTS)
-LIST(APPEND BOOST_COMPONENTS thread
-                             date_time
+LIST(APPEND BOOST_COMPONENTS date_time
                              filesystem
                              system
                              chrono
-                             unit_test_framework
-                             locale)
+                             unit_test_framework)
 
 SET( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -17,7 +17,6 @@
 #include <boost/config.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/thread.hpp>
 #include <boost/throw_exception.hpp>
 
 #include <array>
@@ -82,7 +81,6 @@ namespace chainbase {
 
    typedef boost::interprocess::interprocess_sharable_mutex read_write_mutex;
    typedef boost::interprocess::sharable_lock< read_write_mutex > read_lock;
-   typedef boost::unique_lock< read_write_mutex > write_lock;
 
    /**
     *  Object ID type that includes the type of the object it references


### PR DESCRIPTION
Causes grief on new compiler + old boost combos