### PR TITLE
Move DB environment record & dirty flag in to separate header

### DIFF
--- a/include/chainbase/environment.hpp
+++ b/include/chainbase/environment.hpp
@@ -1,0 +1,79 @@
+#pragma once
+#include <chainbase/pinnable_mapped_file.hpp>
+#include <iomanip>
+
+namespace chainbase {
+
+constexpr size_t header_size = 1024;
+constexpr uint64_t header_id = 0x3242444f49534f45ULL; //"EOSIODB2" little endian
+
+struct environment  {
+   environment() {
+      strncpy(compiler, __VERSION__, sizeof(compiler)-1);
+   }
+
+   enum os_t : unsigned char {
+      OS_LINUX,
+      OS_MACOS,
+      OS_WINDOWS,
+      OS_OTHER
+   };
+   enum arch_t : unsigned char {
+      ARCH_X86_64,
+      ARCH_ARM,
+      ARCH_RISCV,
+      ARCH_OTHER
+   };
+
+   bool debug =
+#ifndef NDEBUG
+      true;
+#else
+      false;
+#endif
+   os_t os =
+#if defined(__linux__)
+      OS_LINUX;
+#elif defined(__APPLE__)
+      OS_MACOS;
+#elif defined(_WIN32)
+      OS_WINDOWS;
+#else
+      OS_OTHER;
+#endif
+   arch_t arch =
+#if defined(__x86_64__)
+      ARCH_X86_64;
+#elif defined(__aarch64__)
+      ARCH_ARM;
+#elif defined(__riscv__)
+      ARCH_RISCV;
+#else
+      ARCH_OTHER;
+#endif
+
+   unsigned boost_version = BOOST_VERSION;
+   uint8_t reserved[512] = {};
+   char compiler[256] = {};
+
+   bool operator==(const environment& other) {
+      return !memcmp(this, &other, sizeof(environment));
+   } 
+   bool operator!=(const environment& other) {
+      return !(*this == other);
+   }
+} __attribute__ ((packed));
+
+struct db_header  {
+   uint64_t id = header_id;
+   bool dirty = false;
+   environment environ;
+} __attribute__ ((packed));
+
+constexpr size_t header_dirty_bit_offset = offsetof(db_header, dirty);
+
+static_assert(sizeof(db_header) <= header_size, "DB header struct too large");
+
+std::ostream& operator<<(std::ostream& os, const chainbase::environment& dt);
+
+}

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -21,18 +21,17 @@ class pinnable_mapped_file {
       };
 
       pinnable_mapped_file(const bfs::path& dir, bool writable, uint64_t shared_file_size, bool allow_dirty, map_mode mode, std::vector<std::string> hugepage_paths);
-      pinnable_mapped_file(pinnable_mapped_file&&) = default;
-      pinnable_mapped_file& operator=(pinnable_mapped_file&&) = default;
+      pinnable_mapped_file(pinnable_mapped_file&& o);
+      pinnable_mapped_file(const pinnable_mapped_file&) = delete;
+      pinnable_mapped_file& operator=(const pinnable_mapped_file&) = delete;
       ~pinnable_mapped_file();
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
 
    private:
       void                                          set_mapped_file_db_dirty(bool);
-      void                                          msync_boost_mapped_file();
       void                                          load_database_file(boost::asio::io_service& sig_ios);
       void                                          save_database_file();
-      void                                          finialize_database_file(bool*);
       bool                                          all_zeros(char* data, size_t sz);
       bip::mapped_region                            get_huge_region(const std::vector<std::string>& huge_paths);
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -10,8 +10,6 @@ namespace chainbase {
 namespace bip = boost::interprocess;
 namespace bfs = boost::filesystem;
 
-constexpr char _db_dirty_flag_string[] = "db_dirty_flag";
-
 class pinnable_mapped_file {
    public:
       typedef typename bip::managed_mapped_file::segment_manager segment_manager;
@@ -28,6 +26,7 @@ class pinnable_mapped_file {
       segment_manager* get_segment_manager() const { return _segment_manager;}
 
    private:
+      void                                          set_mapped_file_db_dirty(bool);
       void                                          msync_boost_mapped_file();
       void                                          load_database_file(boost::asio::io_service& sig_ios);
       void                                          save_database_file();
@@ -35,12 +34,12 @@ class pinnable_mapped_file {
       bool                                          all_zeros(char* data, size_t sz);
       bip::mapped_region                            get_huge_region(const std::vector<std::string>& huge_paths);
 
-      std::unique_ptr<bip::managed_mapped_file>     _mapped_file;
       bip::file_lock                                _mapped_file_lock;
       bfs::path                                     _data_file_path;
       std::string                                   _database_name;
       bool                                          _writable;
 
+      bip::mapped_region                            _file_mapped_region;
       bip::mapped_region                            _mapped_region;
 
 #ifdef _WIN32


### PR DESCRIPTION
The environment record and dirty flag were being stored inside of the managed_mapped_file's segment_manager. In practice this was fragile for its intended purpose: different boost and compiler versions were sometimes unable to read these fields; sometimes even just locking up on a mutex that will never clear.

Move the environment record and dirty flag in to a 1KB header that is placed at the beginning of the file before the segment_manager. This means we lose the ability to use managed_mapped_file and have to do a few operations it did manually now. But these items are stored in a simple plain way that will not depend on compiler version, boost version, and such, so reliability of proper operation should be much higher

🚨🚨Once this is merged old databases will not be useable with the new database code. Intended for merge as part of `forced-replay` merge.