### PR TITLE
Use imported targets for boost & other minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,14 @@
 # Defines ChainBase library target.
 project( ChainBase )
-cmake_minimum_required( VERSION 2.8.12 )
+cmake_minimum_required( VERSION 3.5 )
 
 #list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules" )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
-SET(BOOST_COMPONENTS)
-LIST(APPEND BOOST_COMPONENTS date_time
-                             filesystem
-                             system
-                             chrono
-                             unit_test_framework)
-
 SET( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
+
+include( GNUInstallDirs )
 
 IF( WIN32 )
   SET(BOOST_ROOT $ENV{BOOST_ROOT})
@@ -21,20 +16,25 @@ IF( WIN32 )
   set(BOOST_ALL_DYN_LINK OFF) # force dynamic linking for all libraries
 ENDIF(WIN32)
 
-FIND_PACKAGE(Boost 1.57 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+FIND_PACKAGE(Boost 1.57 REQUIRED COMPONENTS filesystem unit_test_framework)
 
 SET(PLATFORM_LIBRARIES)
+
+if(CMAKE_CXX_STANDARD EQUAL 98)
+   message(FATAL_ERROR "chainbase requires c++14 or newer")
+elseif(NOT CMAKE_CXX_STANDARD)
+   set(CMAKE_CXX_STANDARD 14)
+   set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 if( APPLE )
   # Apple Specific Options Here
   message( STATUS "Configuring ChainBase on OS X" )
-  set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -stdlib=libc++ -Wall -Wno-conversion" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-conversion" )
 else( APPLE )
   # Linux Specific Options Here
   message( STATUS "Configuring ChainBase on Linux" )
-  set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -Wall" )
-  set( rt_library rt )
-  set( pthread_library pthread)
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" )
   if ( FULL_STATIC_BUILD )
     set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
   endif ( FULL_STATIC_BUILD )
@@ -64,8 +64,8 @@ endif()
 
 file(GLOB HEADERS "include/chainbase/*.hpp")
 add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS} )
-target_link_libraries( chainbase  ${Boost_LIBRARIES} ${PLATFORM_LIBRARIES} )
-target_include_directories( chainbase PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"  ${Boost_INCLUDE_DIR} )
+target_link_libraries( chainbase Boost::filesystem ${PLATFORM_LIBRARIES} )
+target_include_directories( chainbase PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
 add_subdirectory( test )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/chainbase DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB UNIT_TESTS "*.cpp")
 add_executable( chainbase_test ${UNIT_TESTS}  )
-target_link_libraries( chainbase_test  chainbase ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chainbase_test  chainbase Boost::unit_test_framework ${OPENSSL_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} )
 


### PR DESCRIPTION
Use boost imported targets so that compiles with boost 1.70 work when using the new cmake config files. Also, change how the c++ standard is getting set so that it’s more modern and also doesn’t stomp on flags.