### PR TITLE
don’t keep file mapping active when in heap/locked mode

### DIFF
--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -41,6 +41,7 @@ class pinnable_mapped_file {
       std::string                                   _database_name;
       bool                                          _writable;
 
+      bip::file_mapping                             _file_mapping;
       bip::mapped_region                            _file_mapped_region;
       bip::mapped_region                            _mapped_region;
 


### PR DESCRIPTION
When in heap or locked mapping mode, pinnable_mapped_file initially maps the database so that it can copy its contents in to the heap/locked memory. Then on shutdown it copies the heap/locked memory back to that mapped file.

This means that during execution in heap/locked mode the process actually shows double memory usage as expected: once for the mapped file that is kept around, and once for the heap/locked memory.

This change closes the mapping after its contents have been copied to the heap/locked memory. It then reopens the mapping on shutdown so that the contents can be copied back. So now during execution the database is only consuming the expected memory