### PR TITLE
print name of DB causing failure condition

### DIFF
--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -44,11 +44,11 @@ pinnable_mapped_file::pinnable_mapped_file(const bfs::path& dir, bool writable, 
 
       db_header* dbheader = reinterpret_cast<db_header*>(header);
       if(dbheader->id != header_id)
-         BOOST_THROW_EXCEPTION(std::runtime_error("chainbase database format not compatible with this version of chainbase."));
+         BOOST_THROW_EXCEPTION(std::runtime_error("\"" + _database_name + "\" database format not compatible with this version of chainbase."));
       if(!allow_dirty && dbheader->dirty)
-         throw std::runtime_error("database dirty flag set");
+         throw std::runtime_error("\"" + _database_name + "\" database dirty flag set");
       if(dbheader->dbenviron != environment()) {
-         std::cerr << "CHAINBASE: Database was created with a chainbase from a different environment" << std::endl;
+         std::cerr << "CHAINBASE: \"" << _database_name << "\" database was created with a chainbase from a different environment" << std::endl;
          std::cerr << "Current compiler environment:" << std::endl;
          std::cerr << environment();
          std::cerr << "DB created with compiler environment:" << std::endl;


### PR DESCRIPTION
nodeos actually uses two chainbase DBs: state & reversible. When there is an error on one of these DBs (like that it’s dirty, or it fails the environment check) it’s not clear which DB is the culprit. Add the name of the DB in the exception so it is clear.