### PR TITLE
two useful 1.8 backports for chainbase

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -9,6 +9,7 @@
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/sync/interprocess_sharable_mutex.hpp>
 #include <boost/interprocess/sync/sharable_lock.hpp>
+#include <boost/core/demangle.hpp>
 
 #include <boost/multi_index_container.hpp>
 

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -44,11 +44,11 @@ pinnable_mapped_file::pinnable_mapped_file(const bfs::path& dir, bool writable, 
 
       db_header* dbheader = reinterpret_cast<db_header*>(header);
       if(dbheader->id != header_id)
-         BOOST_THROW_EXCEPTION(std::runtime_error("chainbase database format not compatible with this version of chainbase."));
+         BOOST_THROW_EXCEPTION(std::runtime_error("\"" + _database_name + "\" database format not compatible with this version of chainbase."));
       if(!allow_dirty && dbheader->dirty)
-         throw std::runtime_error("database dirty flag set");
+         throw std::runtime_error("\"" + _database_name + "\" database dirty flag set");
       if(dbheader->environ != environment()) {
-         std::cerr << "CHAINBASE: Database was created with a chainbase from a different environment" << std::endl;
+         std::cerr << "CHAINBASE: \"" << _database_name << "\" database was created with a chainbase from a different environment" << std::endl;
          std::cerr << "Current compiler environment:" << std::endl;
          std::cerr << environment();
          std::cerr << "DB created with compiler environment:" << std::endl;


### PR DESCRIPTION
This backports #50 (the fix for boost 1.71) and #49 (printing which DB causes typical startup failures). These are small and useful for 1.8 users.