### PR TITLE
fix a few issues with chainbase unit test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB UNIT_TESTS "*.cpp")
 add_executable( chainbase_test ${UNIT_TESTS}  )
-target_link_libraries( chainbase_test  chainbase Boost::unit_test_framework ${OPENSSL_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chainbase_test  chainbase Boost::unit_test_framework ${PLATFORM_SPECIFIC_LIBS} )
 
+add_test(chainbase_test chainbase_test)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -40,7 +40,7 @@ CHAINBASE_SET_INDEX_TYPE( book, book_index )
 
 
 BOOST_AUTO_TEST_CASE( open_and_create ) {
-   boost::filesystem::path temp = boost::filesystem::unique_path();
+   boost::filesystem::path temp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
    try {
       std::cerr << temp << " \n";
 
@@ -129,6 +129,7 @@ BOOST_AUTO_TEST_CASE( open_and_create ) {
       bfs::remove_all( temp );
       throw;
    }
+   bfs::remove_all( temp );
 }
 
 // BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* create the temp DB in the system's temp directory
* remove the temp DB in successful runs
* add unit test to ctest so it's run during CI, etc
* remove OPENSSL_LIBRARIES linkage; why was that there