### PR TITLE
fix error on DB shrink attempt while in 'heap' mode

### DIFF
--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -75,6 +75,11 @@ pinnable_mapped_file::pinnable_mapped_file(const bfs::path& dir, bool writable, 
             grow = shared_file_size - existing_file_size;
             bfs::resize_file(_data_file_path, shared_file_size);
          }
+         else if(shared_file_size < existing_file_size) {
+             std::cerr << "CHAINBASE: \"" << _database_name << "\" requested size of " << shared_file_size << " is less than "
+                "existing size of " << existing_file_size << ". This database will not be shrunk and will "
+                "remain at " << existing_file_size << std::endl;
+         }
          _file_mapping = bip::file_mapping(_data_file_path.generic_string().c_str(), bip::read_write);
          _file_mapped_region = bip::mapped_region(_file_mapping, bip::read_write);
          file_mapped_segment_manager = reinterpret_cast<segment_manager*>((char*)_file_mapped_region.get_address()+header_size);
@@ -114,7 +119,7 @@ pinnable_mapped_file::pinnable_mapped_file(const bfs::path& dir, bool writable, 
 
       try {
          if(mode == heap)
-            _mapped_region = bip::mapped_region(bip::anonymous_shared_memory(shared_file_size));
+            _mapped_region = bip::mapped_region(bip::anonymous_shared_memory(_file_mapped_region.get_size()));
          else
             _mapped_region = get_huge_region(hugepage_paths);
 
@@ -186,7 +191,7 @@ void pinnable_mapped_file::load_database_file(boost::asio::io_service& sig_ios) 
 
       if(time(nullptr) != t) {
          t = time(nullptr);
-         std::cerr << "              " << offset/(_mapped_region.get_size()/100) << "% complete..." << std::endl;
+         std::cerr << "              " << offset/(_file_mapped_region.get_size()/100) << "% complete..." << std::endl;
       }
       sig_ios.poll();
    }

--- a/test/grow_shrink.cpp
+++ b/test/grow_shrink.cpp
@@ -1,0 +1,34 @@
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+#include <chainbase/chainbase.hpp>
+
+using namespace chainbase;
+
+const pinnable_mapped_file::map_mode test_modes[] = {pinnable_mapped_file::map_mode::mapped, pinnable_mapped_file::map_mode::heap};
+
+BOOST_DATA_TEST_CASE(grow_shrink, boost::unit_test::data::make(test_modes), map_mode) {
+   boost::filesystem::path temp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+   try {
+      const size_t db_start_size  = 8u*1024u*1024u;
+      const size_t db_grow_size   = 16u*1024u*1024u;
+      const size_t db_shrunk_size = 2u*1024u*1024u;
+
+      {
+         chainbase::database db(temp, database::read_write, db_start_size, false, map_mode);
+      }
+      {
+         chainbase::database db(temp, database::read_write, db_grow_size, false, map_mode);
+	 BOOST_CHECK(db.get_free_memory() > db_start_size);
+      }
+      {
+         chainbase::database db(temp, database::read_write, db_shrunk_size, false, map_mode);
+	 BOOST_CHECK(db.get_free_memory() > db_start_size);
+      }
+
+   } catch(...) {
+      bfs::remove_all(temp);
+      throw;
+   }
+   bfs::remove_all(temp);
+}


### PR DESCRIPTION
chainbase does not allow the DB to be shrunk. If attempting this, the current expected behavior is to ignore the shrinkage request. However in heap mode w/o hugepages, there was an error where the wrong size gets plumbed through in this situation. Worst case can cause a crash on shutdown due to the mismatch.

Fix this error. Also add a warning telling users that the DB isn't being shrunk. Also add a small unittest.

Resolves EOSIO/eos#8204. Will need backporting to 2.0 & 1.8