### PR TITLE
Fix test error: set allow_dirty to true for db2 to make test pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ if(WIN32)
    target_link_libraries( chainbase ws2_32 mswsock )
 endif()
 
+enable_testing()
 add_subdirectory( test )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/chainbase DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,4 @@ file(GLOB UNIT_TESTS "*.cpp")
 add_executable( chainbase_test ${UNIT_TESTS}  )
 target_link_libraries( chainbase_test  chainbase Boost::unit_test_framework ${OPENSSL_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} )
 
+add_test(NAME test_chainbase COMMAND chainbase_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE( open_and_create ) {
       std::cerr << temp << " \n";
 
       chainbase::database db(temp, database::read_write, 1024*1024*8);
-      chainbase::database db2(temp); /// open an already created db
+      chainbase::database db2(temp, database::read_only, 0, true); /// open an already created db
       BOOST_CHECK_THROW( db2.add_index< book_index >(), std::runtime_error ); /// index does not exist in read only database
 
       db.add_index< book_index >();
@@ -129,6 +129,7 @@ BOOST_AUTO_TEST_CASE( open_and_create ) {
       bfs::remove_all( temp );
       throw;
    }
+   bfs::remove_all( temp );
 }
 
 // BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Previously, in `test/test.cpp` of the branch `v2.0.x`, it was

```c++
chainbase::database db(temp, database::read_write, 1024*1024*8);
chainbase::database db2(temp); /// open an already created db
```

**The test would always fail,** complaining that `database dirty flag set`.

Now the above code is changed into

```c++
chainbase::database db(temp, database::read_write, 1024*1024*8);
chainbase::database db2(temp, database::read_only, 0, true); /// open an already created db
```

so that it becomes okay for `db2` to start off from a dirty database opened by `db`, and thus the test would pass.

Note that the branch `v2.0.x` is currently tracked by both the `master` and `release/2.0.x` branches of `EOSIO/eos`. It would be desired if we can make the test pass.

