### PR TITLE
Potential fix for -Wunused-variable compiler warning.

### DIFF
--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -189,7 +189,11 @@ void pinnable_mapped_file::setup_non_file_mapping() {
       _non_file_mapped_mapping_size = (_non_file_mapped_mapping_size + (r-1u))/r*r;
    };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
    const unsigned _1gb = 1u<<30u;
+#pragma GCC diagnostic pop
+
    const unsigned _2mb = 1u<<21u;
 
 #if defined(MAP_HUGETLB) && defined(MAP_HUGE_1GB)

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -189,14 +189,10 @@ void pinnable_mapped_file::setup_non_file_mapping() {
       _non_file_mapped_mapping_size = (_non_file_mapped_mapping_size + (r-1u))/r*r;
    };
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-   const unsigned _1gb = 1u<<30u;
-#pragma GCC diagnostic pop
-
    const unsigned _2mb = 1u<<21u;
 
 #if defined(MAP_HUGETLB) && defined(MAP_HUGE_1GB)
+   const unsigned _1gb = 1u<<30u;
    _non_file_mapped_mapping = mmap(NULL, _non_file_mapped_mapping_size, PROT_READ|PROT_WRITE, common_map_opts|MAP_HUGETLB|MAP_HUGE_1GB, -1, 0);
    if(_non_file_mapped_mapping != MAP_FAILED) {
       round_up_mmaped_size(_1gb);


### PR DESCRIPTION
When building in clang, this warning appears.  I couldn't deduce if this variable could be removed, so I decided to inhibit the compiler warning.