### PR TITLE
merge back pull67 to v21x epe823

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ if(WIN32)
    target_link_libraries( chainbase ws2_32 mswsock )
 endif()
 
+enable_testing()
 add_subdirectory( test )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/chainbase DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 


### PR DESCRIPTION
Start 78 description ......

EPE 823

Merge back pull67 to 2.1.xbranch.
cherry-pick from pull67
As v2.1.x branch already changed 2 lines where the pull 67 changed, only one line change left for this PR.

The changes are not showing as same lines as pull67 because some lines were already changed as pull67 doing.


The changes are not showing as same lines as pull67 because some lines were already changed as pull67 doing.

End 78 description ......